### PR TITLE
Resolve task version chain bug (#374)

### DIFF
--- a/CareKit/CareKit/Synchronized View Controllers/Task/View Controllers/OCKTaskViewController.swift
+++ b/CareKit/CareKit/Synchronized View Controllers/Task/View Controllers/OCKTaskViewController.swift
@@ -112,7 +112,7 @@ UIViewController, OCKTaskViewDelegate {
 
     // Reset view state on a failure
     // Note: This is needed because the UI assumes user interactions (lke button taps) will be successful, and displays the corresponding
-    // state immedately. When the interaction is actually unsuccessful, we need to reset the UI.
+    // state immediately. When the interaction is actually unsuccessful, we need to reset the UI.
     func resetViewState() {
         controller.objectWillChange.value = controller.objectWillChange.value // triggers an update to the view
     }


### PR DESCRIPTION
* Ensure task view controllers update when their watched task changes

* Address version look up logic error

This commit addresses a logic error in the store's recursive event fetch method. When fetching events from old versions of a task, the query start date was being set to a date that was later than the query applied at the beginning of the recursion. This resulted in invalid date ranges when recursing back more than one task version.

* Fix single event query bug 

This commit addresses a problem in which fetchEvent(task:occurrence:) would fail if the outcome for the event was nil.

The solution was to use the fetchOutcomes (plural) method instead of fetchOutcome (singular) because the former succeeds with an empty array when no outcomes exist.