### PR TITLE
Fix #439

### DIFF
--- a/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
+++ b/CareKitStore/CareKitStore/Protocols/CoreData/OCKCoreDataTaskStore.swift
@@ -283,6 +283,7 @@ extension OCKCoreDataTaskStoreProtocol {
     func makeValue(persistableValue: OCKCDOutcomeValue) -> OCKOutcomeValue {
         var value = OCKOutcomeValue(persistableValue.value, units: persistableValue.units)
         value.index = persistableValue.index?.intValue
+        value.kind = persistableValue.kind
         value.copyCommonValues(from: persistableValue)
         return value
     }

--- a/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
+++ b/CareKitStore/CareKitStoreTests/OCKStore/TestStore+Outcomes.swift
@@ -51,11 +51,15 @@ class TestStoreOutcomes: XCTestCase {
         let task = try store.addTaskAndWait(OCKTask(id: "A", title: "A", carePlanUUID: nil, schedule: schedule))
         let taskUUID = try task.getUUID()
 
-        let value = OCKOutcomeValue(42)
+        var value = OCKOutcomeValue(42)
+        value.kind = "number"
+
         var outcome = OCKOutcome(taskUUID: taskUUID, taskOccurrenceIndex: 0, values: [value])
         outcome = try store.addOutcomeAndWait(outcome)
+
         let outcomes = try store.fetchOutcomesAndWait()
         XCTAssert(outcomes == [outcome])
+        XCTAssert(outcomes.first?.values.first?.kind == "number")
         XCTAssertNotNil(outcomes.first?.taskUUID)
         XCTAssertNotNil(outcomes.first?.schemaVersion)
     }


### PR DESCRIPTION
OCKOutcomeValue's kind property was being persisted, but was not being populated onto structs when rehydrated from CoreData.